### PR TITLE
packet: Fix cf60970052db47214623972738b2c292a7e889b8

### DIFF
--- a/net/packet/af_packet.c
+++ b/net/packet/af_packet.c
@@ -1485,7 +1485,7 @@ static int fanout_add(struct sock *sk, u16 id, u16 type_flags)
 	}
 	spin_unlock(&po->bind_lock);
 
-	if (err && !refcount_read(&match->sk_ref)) {
+	if (err && !atomic_read(&match->sk_ref)) {
 		list_del(&match->list);
 		kfree(match);
 	}


### PR DESCRIPTION
I screwed up the resolution on this one, refcount_read is the function
from upstream, which doesn't exist in 3.18. Use the proper function
atomic_read from the backport to 3.18.

Signed-off-by: Nathan Chancellor <natechancellor@gmail.com>